### PR TITLE
Input handling (to take log_format instead of separator and column_idx)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+  - "3.6"
+script:
+ - python -m unittest

--- a/MoLFI.py
+++ b/MoLFI.py
@@ -12,7 +12,7 @@ from main.org.core.metaheuristics.NSGA_II_2D import main
     this script is a wrapper for the MoLFI tool and can be used from the command line as following
     under the SB_Template_Extraction:
     run the MoLFI script with the required arguments:
-        python3.6 path/to/MoLFI.py -l [logfile.log] -c [msg_pos] -s [char_separator] -p [serialize_file]
+        python3.6 path/to/MoLFI.py -l [logfile.log] -f [log_format] -p [serialize_file]
 
         Optional parameters are: the list of regex with -r/--regex
 
@@ -20,10 +20,9 @@ from main.org.core.metaheuristics.NSGA_II_2D import main
 
 cmdline = argparse.ArgumentParser(
     usage="\
-    \t MoLFI.py --log logfile.txt --seperator 'char' --column msg_pos --regex $'rx1' $'rx2' $'rx3' --pklfile serialze_file\n \
+    \t MoLFI.py --log logfile.txt --format '<ts> <level> <message>' --regex $'rx1' $'rx2' $'rx3' --pklfile serialze_file\n \
     \t--log: \t\t\t the log file\n \
-    \t--seperator: \t\t a specific charchter (string) that seperates the columns of the log file\n\
-    \t--column: \t\t the index of the log messages column\n \
+    \t--format: \t\t a log format for log lines (e.g., <timestamp> <level> <message>)\n\
     \t--pklfile: \t\t the file where to save the serialized generated templates\n \
     \t--regex: \t\t a list of regular expressions that detects domain knowledge variables",
     description='MoLFI: Multi-Objective Log Message Format Identification:\n \
@@ -35,18 +34,11 @@ cmdline.add_argument('--log',
                      dest='alog',
                      required=True
                      )
-cmdline.add_argument('--separator',
-                     '-s',
+cmdline.add_argument('--format',
+                     '-f',
                      action='store',
-                     help=r"The separator between the log's columns",
-                     dest='aseparator',
-                     required=True
-                     )
-cmdline.add_argument('--column',
-                     '-c',
-                     action='store',
-                     help=r"The column number of the log messages",
-                     dest='acolumn',
+                     help=r"The log format for a line (e.g., <date> <message>)",
+                     dest='aformat',
                      required=True
                      )
 cmdline.add_argument('--regex',
@@ -76,10 +68,10 @@ else:
     regx = None
 
 # Load log messages
-chrom_gen = ChromosomeGenerator(str(args.alog), int(args.acolumn), str(args.aseparator), regex=regx)
+chrom_gen = ChromosomeGenerator(str(args.alog), str(args.aformat), regex=regx)
 pareto = main(chrom_gen)
 
 # serialize the pareto solution to a file
-binary_file = open(args.apklfile,mode='wb')
-my_pickled_mary = pickle.dump(pareto, binary_file)
+binary_file = open(args.apklfile, mode='wb')
+pickle.dump(pareto, binary_file)
 binary_file.close()

--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ To run MoLFI on a single log file:
 
 - from the command line, run the MoLFI.py script and precise the following arguments:
 *  -l : specify the log file
-*  -f : specify the log format (e.g., "<timestamp> <level> <message>")
+*  -f : specify the log format (e.g., `"<timestamp> <level> <message>"`)
 *  -p : specify where to save the generated templates.
 *  -r : provide the regular expressions if any (one after the other, separated by a normal space)
 
 Example:
-
+```shell script
 python3 MoLFI.py -l ../MoLFI_experiments/Datasets/BGL/2K/BGL_2K_log_messages.txt -f "<message>" -p templates.pkl -r "core\.[0-9]*" "0x([a-zA-Z]|[0-9])+"
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# MoLFI
+[![Build Status](https://travis-ci.org/donghwan-shin/MoLFI.svg?branch=master)](https://travis-ci.org/donghwan-shin/MoLFI)
+
+# MoLFI 
 Multi-objective Log message Format Identification
 
 MoLFI is a tool implementing a search-based approach to solve the problem of log message format identification.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ MoLFI applies the following steps:
 1. Run NSGA-II algorithm.
 1. Post-processing: apply corrections to the resulting solutions.
 
-MoLFI is implemented as a python project (v3.6.0).
+MoLFI is implemented as a python project (v3.6+).
 
 This package contains the source code of the tool with two executable scripts.
 
@@ -44,11 +44,10 @@ To run MoLFI on a single log file:
 
 - from the command line, run the MoLFI.py script and precise the following arguments:
 *  -l : specify the log file
-*  -s : specify the separator of the log file contents (e.g. a comma, a tab character)
-*  -c : precise the position of the log messages in the log file (e.g. 3 for third column)
+*  -f : specify the log format (e.g., "<timestamp> <level> <message>")
 *  -p : specify where to save the generated templates.
 *  -r : provide the regular expressions if any (one after the other, separated by a normal space)
 
 Example:
 
-python3.6 MoLFI.py -l ../MoLFI_experiments/Datasets/BGL/2K/BGL_2K_log_messages.txt -s "\n" -c 0 -p templates.pkl -r "core\.[0-9]*" "0x([a-zA-Z]|[0-9])+"
+python3 MoLFI.py -l ../MoLFI_experiments/Datasets/BGL/2K/BGL_2K_log_messages.txt -f "<message>" -p templates.pkl -r "core\.[0-9]*" "0x([a-zA-Z]|[0-9])+"

--- a/main/org/core/utility/log_file_reader.py
+++ b/main/org/core/utility/log_file_reader.py
@@ -1,3 +1,9 @@
+import pandas as pd
+import re
+import os
+
+import logging
+logger = logging.getLogger(__name__)
 
 
 def log_file_reader(logpath):
@@ -7,3 +13,49 @@ def log_file_reader(logpath):
 
     return lines
 
+
+def load_logs_into_df(log_format: str, log_files: list):
+    """
+    Load logs with parsing according to the given log format.
+    :param log_format:
+    :param log_files:
+    :return:
+    """
+    header, pattern = generate_pattern_from_log_format(log_format)
+    if 'message' not in header:
+        print(f'ERROR: <message> is not in log_format={log_format}')
+        exit(-1)
+
+    log_id = 1
+    log_dfs = []
+    for file in log_files:
+        log_lines = []
+        with open(file, 'r', errors='replace') as log:
+            for line in log:
+                m = re.match(pattern, line.strip())
+                if m:
+                    log_line = [m.group(h) for h in header]
+                    log_lines.append(log_line)
+                else:
+                    logger.debug(f'Skip non-matched log_line={line.strip()}')
+        log_df = pd.DataFrame(log_lines, columns=header)
+        log_df.insert(0, 'lineID', None)
+        log_df['lineID'] = [i + 1 for i in range(len(log_lines))]
+        log_df.insert(0, 'logID', log_id)
+        log_id += 1
+        log_dfs.append(log_df)
+        logger.info(f'loaded log file (lines=%d): %s' % (len(log_lines), file))
+
+    logs_df = pd.concat(log_dfs, ignore_index=True)
+    print(f'Total number of log messages in raw logs: %d' % len(logs_df))
+
+    return logs_df
+
+
+def generate_pattern_from_log_format(log_format: str):
+    header = re.findall(r'<(\S+?)>', log_format)
+    pattern = re.sub(r'(<\S+?>)', r'(?P\1.+?)', log_format)
+    pattern = re.sub(r'<(\S+)_ext>\.\+\?', r'<\1_ext>.+', pattern)
+    pattern = re.sub(r'\s+', r'\\s+', pattern)
+    pattern = '^' + pattern + '$'
+    return header, pattern

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 deap
 numpy
+pandas

--- a/test/org/core/fitness/test_objectives2D.py
+++ b/test/org/core/fitness/test_objectives2D.py
@@ -8,7 +8,7 @@ class Test(unittest.TestCase):
 
     def test_constructor(self):
         logfile = ROOT_DIR + '/test/resources/File.log'
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', [])
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', [])
         obj2_d = Objective2D(chrom_gen)
         self.assertEqual(len(obj2_d.get_messages()), 15)
 
@@ -21,14 +21,14 @@ class Test(unittest.TestCase):
         chromosome.add_template(t)
         # let's read the messages
         logfile = ROOT_DIR + '/test/resources/File.log'
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', [])
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', [])
         obj2_d = Objective2D(chrom_gen)
         # assertion section
         self.assertEqual(obj2_d.compute_objective(chromosome), [1.0, 0])
 
     def test_star_template(self):
         logfile = ROOT_DIR + '/test/resources/File.log'
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', [])
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', [])
 
         t = Template(["*", "*", "*"])
         compute_matched_lines(chrom_gen.messages, t)
@@ -40,7 +40,7 @@ class Test(unittest.TestCase):
 
     def test_compute_objective(self):
         logfile = ROOT_DIR + '/test/resources/File.log'
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', ["'[\w\d\$\-:,\./_ ><\|]*'"])
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', ["'[\w\d\$\-:,\./_ ><\|]*'"])
 
         template1 = ["Message", "sent", "by", "*", ",", "at", "port", "*"]
         template2 = ["generating", "reading", "files"]

--- a/test/org/core/operators/test_mutation.py
+++ b/test/org/core/operators/test_mutation.py
@@ -6,14 +6,14 @@ from main.org.core.operators.mutation import *
 class Test(unittest.TestCase):
     def test_constructor(self):
         logfile = ROOT_DIR + '/test/resources/File.log'
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', [])
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', [])
         chrom_mutator = ChromosomeMutator(chrom_gen)
 
         self.assertEqual(len(chrom_mutator.chGenerator.messages.keys()), 4)
 
     def test_change_template_one_template(self):
         logfile = ROOT_DIR + '/test/resources/File.log'
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', ["'[\w\d\$\-:,\./_ ><\|]*'"])
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', ["'[\w\d\$\-:,\./_ ><\|]*'"])
         chrom_mutator = ChromosomeMutator(chrom_gen)
         t = chrom_mutator.chGenerator.generate_template_from_line(8, 0)
         chromosome = Chromosome({8: [t]})

--- a/test/org/core/operators/test_mutation_100cov.py
+++ b/test/org/core/operators/test_mutation_100cov.py
@@ -11,7 +11,7 @@ class Test(unittest.TestCase):
 
     def test_apply_mutation(self):
         logfile = ROOT_DIR + '/test/resources/File.log'
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', ["'[\w\d\$\-:,\./_ ><\|]*'"])
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', ["'[\w\d\$\-:,\./_ ><\|]*'"])
         chrom_mutator_100 = ChromosomeMutator100cov(chrom_gen)
         template = Template(['Driver', ':', '*'])
         template.matched_lines = [5]
@@ -26,7 +26,7 @@ class Test(unittest.TestCase):
 
     def test_add_template_to_reach_100cov(self):
         logfile = ROOT_DIR + '/test/resources/File.log'
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', ["'[\w\d\$\-:,\./_ ><\|]*'"])
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', ["'[\w\d\$\-:,\./_ ><\|]*'"])
         chrom_mutator_100 = ChromosomeMutator100cov(chrom_gen)
         template = Template(['Message', 'sent', 'by', 'EEE', ',', 'at', 'port', '1'])
         template.matched_lines = [0]

--- a/test/org/core/utility/test_chromosome_generator.py
+++ b/test/org/core/utility/test_chromosome_generator.py
@@ -19,7 +19,7 @@ class Test(unittest.TestCase):
         file.close()
 
     def test_load_log_message(self):
-        chrom_gen = ChromosomeGenerator(self.logfile, 0, '\n', [])
+        chrom_gen = ChromosomeGenerator(self.logfile, '<message>', [])
         msg = Message(['Write', 'data', 'conf', 'to ', 'file', 'ABC'])
         chrom_gen.load_log_message(msg)
         self.assertEqual(len(chrom_gen.messages.keys()), 2)
@@ -28,7 +28,7 @@ class Test(unittest.TestCase):
     def test_constructor(self):
         logfile = ROOT_DIR + '/test/resources/File.log'
         regex = []
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', regex)
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', regex)
         self.assertEqual(len(chrom_gen.messages.keys()), 4)
         self.assertEqual(len(chrom_gen.messages[3]), 7)
         self.assertEqual(len(chrom_gen.messages[7]), 1)
@@ -37,7 +37,7 @@ class Test(unittest.TestCase):
 
     def test_generate_template_from_line(self):
         logfile = ROOT_DIR + '/test/resources/File.log'
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', [])
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', [])
         template = chrom_gen.generate_template_from_line(3, 0)
         message = chrom_gen.messages[3][0]
         for index in range(0, message.get_length()):
@@ -46,7 +46,7 @@ class Test(unittest.TestCase):
 
     def test_generate_template_from_line2(self):
         logfile = ROOT_DIR + '/test/resources/File.log'
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', [])
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', [])
         m = Message(["======================="])
         messages = {1:[m]}
         chrom_gen.messages = messages
@@ -54,14 +54,14 @@ class Test(unittest.TestCase):
         self.assertEqual(template.token, ['======================='])
 
     def test_one_template_100_cov(self):
-        chrom_gen = ChromosomeGenerator(self.logfile, 0, '\n', [])
+        chrom_gen = ChromosomeGenerator(self.logfile, '<message>', [])
         chromosome = chrom_gen.generate_100cov_chromosome()
         self.assertEqual(chromosome.number_of_clusters(), 1)
         self.assertEqual(len(chromosome.templates[3][0].matched_lines), 1)
 
     def test_generate_100cov_chromosome(self):
         logfile = ROOT_DIR + '/test/resources/File.log'
-        chrom_gen = ChromosomeGenerator(logfile, 0, '\n', [])
+        chrom_gen = ChromosomeGenerator(logfile, '<message>', [])
         chromosome = chrom_gen.generate_100cov_chromosome()
         for key in chrom_gen.messages.keys():
             match_lines = set()

--- a/test/resources/File.log
+++ b/test/resources/File.log
@@ -1,0 +1,20 @@
+generating reading files
+Message sent by 'AAA', at port 50
+Message sent by 'CCC', at port 3
+Message sent by 'EEE', at port 1
+Start core code
+target : script.sh
+App : XYZ
+KERNEL    : 5434567
+Server stop process file: config.txt
+Server start process from client ABC
+App : XYZ
+TLB    : BCD
+KERNEL    : 123
+STOP : path/to/server
+STOP : path/to/server
+generating reading files
+Server launch app from file id /path/to/file.txt
+generating reading files
+Message sent by 'DDD', at port 2
+Message sent by 'BBB', at port 50


### PR DESCRIPTION
When I see the input of the original version, it takes not only the log file but also the separator of the log file contents (e.g., a comma or a tab) and the position of the log messages in the log file (e.g., the third column). 

However, when the separator is whitespace (which happens a lot in practice), we cannot specify the position of the log messages in the log file because the messages have whitespaces too. 

So, I changed it to take as input the log file and the header (e.g., `"<timestamp> <level> <component> <message>"`) inspired by [LogParser](https://github.com/logpai/logparser). 

p.s. I also added a missing `test/resources/File.log`.